### PR TITLE
Check page query arg before using htmlspecialchars

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+= 1.8.4 - June 29th, 2023 =
+* Check `page` query arg before wrapping it in `htmlspecialchars`.
+
 = 1.8.3 - June 23rd, 2023
 * Remove unnecessary test data.
 * Regenerate `.pot` file.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "custom-product-tabs",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "custom-product-tabs",
-  "version": "1.8.3",
+  "version": "4",
   "devDependencies": {
     "@foreachbe/cypress-tinymce": "^1.0.0",
     "@wordpress/env": "^5.16.0",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: http://yikesinc.com
 Tags: woocommerce, product tabs, repeatable, duplicate, customize, custom, tabs, product, woo, commerce
 Requires at least: 3.8
 Tested up to: 6.2
-Stable tag: 1.8.3
+Stable tag: 1.8.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -74,13 +74,7 @@ Yes! Since v1.4 we've added the necessary code to ensure the custom tab data is 
 
 == Changelog ==
 
-= 1.8.3 / 2023-06-23 =
+= 1.8.4 / 2023-06-29 =
 
 # Updates
-* Remove unnecessary test data.
-* Regenerate `.pot` file.
-* Remove `FILTER_SANITIZE_STRING` and replace with `htmlspecialchars`.
-* Enable WooCommerce [HPOS](https://github.com/woocommerce/woocommerce/wiki/High-Performance-Order-Storage-Upgrade-Recipe-Book) support. 
-* Bump `WC tested up to:` to 7.8.
-* Bump `Tested up to:` to 6.2.
-* Introduce Cypress `e2e` tests to ensure the plugin is functioning as intended.
+* Check `page` query arg before wrapping it in `htmlspecialchars`.

--- a/tests/test.cypress.js
+++ b/tests/test.cypress.js
@@ -131,6 +131,8 @@ describe( 'Tests', () => {
 		// Check from of site data matches what we added.
 		cy.get( '#message.updated.notice a' ).click();
 
+		cy.wait( 2000 );
+
 		cy.get( '.wc-tabs li.saved-tab-title_tab' ).contains( 'Saved Tab Title' ).click();
 
 		cy.get( '.yikes-custom-woo-tab-title' ).should( 'have.text', 'Saved Tab Title' );

--- a/yikes-inc-easy-custom-woocommerce-product-tabs.php
+++ b/yikes-inc-easy-custom-woocommerce-product-tabs.php
@@ -5,7 +5,7 @@
  * Description: Extend WooCommerce to add and manage custom product tabs. Create as many product tabs as needed per product.
  * Author: YIKES, Inc.
  * Author URI: https://www.yikesinc.com
- * Version: 1.8.3
+ * Version: 1.8.4
  * Text Domain: yikes-inc-easy-custom-woocommerce-product-tabs
  * Domain Path: languages/
  * Tested up to: 6.2
@@ -129,7 +129,7 @@ class YIKES_Custom_Product_Tabs {
 		 * Define the plugin's version.
 		 */
 		if ( ! defined( 'YIKES_Custom_Product_Tabs_Version' ) ) {
-			define( 'YIKES_Custom_Product_Tabs_Version', '1.8.3' );
+			define( 'YIKES_Custom_Product_Tabs_Version', '1.8.4' );
 		}
 
 		/**

--- a/yikes-inc-easy-custom-woocommerce-product-tabs.php
+++ b/yikes-inc-easy-custom-woocommerce-product-tabs.php
@@ -330,7 +330,15 @@ class YIKES_Custom_Product_Tabs {
 	 */
 	public function yikes_custom_product_tabs_admin_footer_text( $footer_text ) {
 
-		$page = htmlspecialchars( filter_input( INPUT_GET, 'page', FILTER_UNSAFE_RAW ) );
+		$page = filter_input( INPUT_GET, 'page', FILTER_UNSAFE_RAW );
+
+		if ( ! $page ) {
+
+			return $footer_text;
+
+		}
+
+		$page = htmlspecialchars( $page );
 
 		$allowed_pages = array(
 			'yikes-woo-settings',
@@ -338,7 +346,7 @@ class YIKES_Custom_Product_Tabs {
 			'yikes-woo-premium',
 		);
 
-		if ( ! $page || ! in_array( $page, $allowed_pages, true ) ) {
+		if ( ! in_array( $page, $allowed_pages, true ) ) {
 
 			return $footer_text;
 


### PR DESCRIPTION
- Check `page` query arg before passing into `htmlspecialchars`.
- Bump version to 1.8.4.
- Update changelog and readme.txt with 1.8.4 changes.